### PR TITLE
feat: add request params to gin logger

### DIFF
--- a/logging/correlation.go
+++ b/logging/correlation.go
@@ -11,6 +11,8 @@ import (
 type ctxKey string
 
 const (
+	LoggerKey = "logger"
+
 	CorrelationIDName         ctxKey = "correlation_id"
 	IntCorrelationIDName      ctxKey = "int_correlation_id"
 	ExternalCorrelationIDName string = "X-Correlation-Id"
@@ -52,7 +54,7 @@ func addLogger(c *gin.Context, l *zap.SugaredLogger) {
 		l = l.With("query", c.Request.URL.RawQuery)
 	}
 
-	c.Set("logger", l)
+	c.Set(LoggerKey, l)
 
 	c.Request = c.Request.WithContext(ctx)
 

--- a/logging/rest.go
+++ b/logging/rest.go
@@ -42,7 +42,7 @@ func LogRequest(fallBackLogger *zap.Logger) gin.HandlerFunc {
 }
 
 func GetLoggerFromContext(c *gin.Context) (*zap.SugaredLogger, error) {
-	value, ok := c.Get("logger")
+	value, ok := c.Get(LoggerKey)
 	if !ok {
 		return nil, fmt.Errorf("logger does not exists in context")
 	}


### PR DESCRIPTION
This PR enriches the logger we already use for gin servers, with fields extracted from request's params (both in the route like /chain/:chain_name that in query params like ?key=42).

I have seen in api-server that a lot of params are manually added each time, so my goal is to clean up the code and automatically add what we can without copy paste 😁 