### PR TITLE
feat: add sentryx.StartSpan method

### DIFF
--- a/sentryx/sentryx.go
+++ b/sentryx/sentryx.go
@@ -1,0 +1,19 @@
+package sentryx
+
+import (
+	"context"
+
+	"github.com/getsentry/sentry-go"
+)
+
+// StartSpan calls sentry.StartSpan and returns the span and the span context.
+// This is handy to ensure correct hierarchy of span if other spans are started
+// after this one. Indeed you need to use the span.Context() to start a child
+// span. Recommanded usage is:
+//
+//     span, ctx := sentryx.StartSpan(ctx, "operation")
+//     defer span.Finish()
+func StartSpan(ctx context.Context, operation string, options ...sentry.SpanOption) (*sentry.Span, context.Context) {
+	s := sentry.StartSpan(ctx, operation, options...)
+	return s, s.Context()
+}


### PR DESCRIPTION
This is a handy method that ensures the context passed to StartSpan can
be overrided with span.Context. Using span.Context is required to make
new span children of the first span.