### PR TITLE
fix(ginsentry): put params in tags instead of span names

### DIFF
--- a/ginsentry/ginsentry.go
+++ b/ginsentry/ginsentry.go
@@ -32,10 +32,13 @@ func Middleware(ctx *gin.Context) {
 
 	// start span for the request
 	span := sentry.StartSpan(ctx.Request.Context(), "http.server",
-		sentry.TransactionName(fmt.Sprintf("%s %s", ctx.Request.Method, ctx.Request.URL.Path)),
+		sentry.TransactionName(fmt.Sprintf("%s %s", ctx.Request.Method, ctx.FullPath())),
 		sentry.ContinueFromRequest(ctx.Request),
 	)
 	defer span.Finish()
+	for _, param := range ctx.Params {
+		span.SetTag(param.Key, param.Value)
+	}
 	ctx.Request = ctx.Request.WithContext(span.Context())
 
 	ctx.Next()


### PR DESCRIPTION
This PR allow grouping of Sentry span by the request handler, and puts the URL params as tags.

Fixes (partly) https://github.com/EmerisHQ/demeris-backend/issues/760. Will need to upgrade api-server to use this new utils version.